### PR TITLE
Fix: Enable Job DSL loading from jobs.groovy file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
     volumes:
       - jenkins_home:/var/jenkins_home
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./jobs.groovy:/var/jenkins_home/jobs.groovy:ro
     group_add:
       - "998"
     user: root

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       - jenkins_home:/var/jenkins_home
       - /var/run/docker.sock:/var/run/docker.sock
       - ./jobs.groovy:/var/jenkins_home/jobs.groovy:ro
+      - ./jenkins.yaml:/var/jenkins_home/jenkins.yaml:ro
     group_add:
       - "998"
     user: root

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -27,5 +27,4 @@ credentials:
               id: "github-creds"
 
 jobs:
-  - script: >
-      evaluate(new File('/var/jenkins_home/jobs.groovy').text)
+  - file: /var/jenkins_home/jobs.groovy

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -28,18 +28,4 @@ credentials:
 
 jobs:
   - script: >
-      pipelineJob('python-hello-world') {
-        definition {
-          cpsScm {
-            scm {
-              git {
-                remote {
-                  url('https://github.com/dbjwhs/jenkins')
-                }
-                branch('*/main')
-              }
-            }
-            scriptPath('Jenkinsfile')
-          }
-        }
-      }
+      evaluate(new File('/var/jenkins_home/jobs.groovy').text)

--- a/jobs.groovy
+++ b/jobs.groovy
@@ -105,12 +105,12 @@ pipelineJob('test-repositories/generic-test-pipeline') {
                                         }
                                     }
                                     steps {
-                                        sh '''
+                                        sh """
                                             pip install --upgrade pip
                                             if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
                                             if [ -f pyproject.toml ]; then pip install -e .; fi
                                             python -m pytest --junit-xml=test-results.xml || true
-                                        '''
+                                        """
                                     }
                                     post {
                                         always {
@@ -299,7 +299,7 @@ pipelineJob('cpp-projects/inference-systems-lab-build') {
                                 }
                             }
                             steps {
-                                sh '''
+                                sh """
                                     apt-get update
                                     apt-get install -y \\
                                         cmake \\
@@ -329,7 +329,7 @@ pipelineJob('cpp-projects/inference-systems-lab-build') {
                                     cmake --version
                                     g++ --version
                                     ninja --version
-                                '''
+                                """
                             }
                         }
                         
@@ -386,7 +386,7 @@ pipelineJob('cpp-projects/inference-systems-lab-build') {
                                     script {
                                         def buildDir = "build-${params.BUILD_TYPE.toLowerCase()}"
                                         dir(buildDir) {
-                                            sh 'cmake --build . --parallel ${CMAKE_BUILD_PARALLEL_LEVEL:-4}'
+                                            sh "cmake --build . --parallel \\${CMAKE_BUILD_PARALLEL_LEVEL:-4}"
                                         }
                                     }
                                 }
@@ -409,15 +409,15 @@ pipelineJob('cpp-projects/inference-systems-lab-build') {
                                     script {
                                         def buildDir = "build-${params.BUILD_TYPE.toLowerCase()}"
                                         dir(buildDir) {
-                                            sh '''
+                                            sh """
                                                 echo "Running CTest..."
-                                                ctest --output-on-failure --parallel ${CTEST_PARALLEL_LEVEL:-4} || true
+                                                ctest --output-on-failure --parallel \${CTEST_PARALLEL_LEVEL:-4} || true
                                                 
                                                 echo "Test results:"
                                                 if [ -f Testing/Temporary/LastTest.log ]; then
                                                     tail -20 Testing/Temporary/LastTest.log
                                                 fi
-                                            '''
+                                            """
                                         }
                                     }
                                 }


### PR DESCRIPTION
## Summary
- ✅ **Fix job loading**: Mount jobs.groovy as volume in docker-compose
- ✅ **Fix JCasC syntax**: Use proper `file:` syntax instead of `evaluate()`  
- ✅ **Fix Groovy errors**: Escape quotes in shell scripts within pipeline definitions
- ✅ **Working jobs**: All job folders now load correctly in Jenkins UI

## Problem Solved
Jenkins wasn't loading jobs from jobs.groovy because:
1. File wasn't mounted in container
2. Wrong JCasC syntax for Job DSL files  
3. Groovy parsing errors from nested quote conflicts

## Result
✅ **test-repositories** folder with generic test pipeline  
✅ **cpp-projects** folder with inference-systems-lab-build  
✅ **example-jobs** folder  
✅ All jobs working and visible in Jenkins UI  

## Changes Made
- Mount jobs.groovy as read-only volume
- Mount jenkins.yaml as read-only volume  
- Fix JCasC Job DSL file reference syntax
- Escape shell script quotes in Groovy pipeline definitions

🤖 Generated with [Claude Code](https://claude.ai/code)