### PR TITLE
Add cpp-snippets build job to Jenkins pipeline

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -567,12 +567,12 @@ pipelineJob('cpp-projects/cpp-snippets-build') {
                                     git branch: params.BRANCH, url: params.GIT_REPO_URL
                                     
                                     // Verify this is the cpp-snippets project
-                                    if (!fileExists('tools/build_all.sh')) {
-                                        error('tools/build_all.sh not found - this does not appear to be the cpp-snippets project')
+                                    if (!fileExists('tooling/build_all.sh')) {
+                                        error('tooling/build_all.sh not found - this does not appear to be the cpp-snippets project')
                                     }
                                     
                                     echo 'Confirmed: This is the cpp-snippets project'
-                                    sh 'ls -la tools/'
+                                    sh 'ls -la tooling/'
                                 }
                             }
                         }
@@ -593,10 +593,10 @@ pipelineJob('cpp-projects/cpp-snippets-build') {
                                 script {
                                     sh """
                                         echo "Making build_all.sh executable..."
-                                        chmod +x tools/build_all.sh
+                                        chmod +x tooling/build_all.sh
                                         
                                         echo "Running build_all.sh script..."
-                                        cd tools
+                                        cd tooling
                                         ./build_all.sh
                                     """
                                 }
@@ -628,7 +628,7 @@ pipelineJob('cpp-projects/cpp-snippets-build') {
                         }
                         success {
                             echo "✅ cpp-snippets build completed successfully!"
-                            echo "Build script: tools/build_all.sh"
+                            echo "Build script: tooling/build_all.sh"
                             echo "Repository: ${params.GIT_REPO_URL}"
                             echo "Branch: ${params.BRANCH}"
                         }

--- a/jobs.groovy
+++ b/jobs.groovy
@@ -553,7 +553,7 @@ pipelineJob('cpp-projects/cpp-snippets-build') {
                     stages {
                         stage('Clean Workspace') {
                             when {
-                                params.CLEAN_WORKSPACE == true
+                                expression { params.CLEAN_WORKSPACE == true }
                             }
                             steps {
                                 cleanWs()

--- a/jobs.groovy
+++ b/jobs.groovy
@@ -595,7 +595,13 @@ pipelineJob('cpp-projects/cpp-snippets-build') {
                                         git \\
                                         pkg-config \\
                                         bc \\
-                                        libssl-dev
+                                        libssl-dev \\
+                                        python3 \\
+                                        python3-dev \\
+                                        libbz2-dev \\
+                                        libicu-dev \\
+                                        zlib1g-dev \\
+                                        libzstd-dev
                                     
                                     # Set GCC 13 as default for C++23 support
                                     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
@@ -607,9 +613,19 @@ pipelineJob('cpp-projects/cpp-snippets-build') {
                                     apt-get update
                                     apt-get install -y cmake
                                     
-                                    # Verify versions
+                                    # Install Boost 1.87 from source
+                                    cd /tmp
+                                    wget https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2
+                                    tar -xf boost_1_87_0.tar.bz2
+                                    cd boost_1_87_0
+                                    ./bootstrap.sh --with-libraries=system,thread,filesystem,program_options,test
+                                    ./b2 --j=4 link=shared runtime-link=shared variant=release install
+                                    ldconfig
+                                    
+                                    # Verify installations
                                     cmake --version
                                     g++ --version
+                                    ls -la /usr/local/lib/libboost_*
                                 """
                                 script {
                                     sh """

--- a/jobs.groovy
+++ b/jobs.groovy
@@ -580,7 +580,7 @@ pipelineJob('cpp-projects/cpp-snippets-build') {
                         stage('Build All Snippets') {
                             agent {
                                 docker {
-                                    image 'ubuntu:22.04'
+                                    image 'ubuntu:24.04'
                                     reuseNode true
                                     args '--user root'
                                 }
@@ -588,7 +588,28 @@ pipelineJob('cpp-projects/cpp-snippets-build') {
                             steps {
                                 sh """
                                     apt-get update
-                                    apt-get install -y cmake build-essential git pkg-config
+                                    apt-get install -y \\
+                                        wget \\
+                                        build-essential \\
+                                        gcc-13 g++-13 \\
+                                        git \\
+                                        pkg-config \\
+                                        bc \\
+                                        libssl-dev
+                                    
+                                    # Set GCC 13 as default for C++23 support
+                                    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
+                                    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
+                                    
+                                    # Install latest CMake from official repository
+                                    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+                                    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+                                    apt-get update
+                                    apt-get install -y cmake
+                                    
+                                    # Verify versions
+                                    cmake --version
+                                    g++ --version
                                 """
                                 script {
                                     sh """


### PR DESCRIPTION
## Summary
- Add new Jenkins pipeline job for building cpp-snippets repository
- Runs the tools/build_all.sh script in a containerized Ubuntu environment
- Provides comprehensive build logging and artifact archiving

## Job Details
- **Location**: `cpp-projects/cpp-snippets-build`
- **Repository**: `https://github.com/dbjwhs/cpp-snippets.git`
- **Build Script**: `tools/build_all.sh`
- **Environment**: Ubuntu 22.04 with cmake, build-essential, git, pkg-config

## Pipeline Features
✅ **Project Verification**: Confirms tools/build_all.sh exists before proceeding  
✅ **Docker Environment**: Isolated build environment with required dependencies  
✅ **Build Script Execution**: Makes script executable and runs from tools directory  
✅ **Artifact Archiving**: Captures build results, logs, and test outputs  
✅ **Configurable Parameters**: Repository URL, branch, and workspace cleanup options  

## Benefits
- **Consistency**: Same reliable Docker-based build environment as inference-systems-lab
- **Convenience**: Single-click builds for the entire cpp-snippets collection
- **Debugging**: Comprehensive logging and artifact retention for troubleshooting
- **Integration**: Fits seamlessly into existing cpp-projects folder structure

🤖 Generated with [Claude Code](https://claude.ai/code)