### PR TITLE
Fix: Automate Jenkins script approvals for Job DSL

### DIFF
--- a/approve-scripts.groovy
+++ b/approve-scripts.groovy
@@ -1,0 +1,35 @@
+#!/usr/bin/env groovy
+
+// Jenkins script console script to auto-approve all pending scripts
+// Usage: Run this in Jenkins Script Console (Manage Jenkins > Script Console)
+// Or via CLI: java -jar jenkins-cli.jar -s http://localhost:8080 groovy approve-scripts.groovy
+
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval
+
+def scriptApproval = ScriptApproval.get()
+
+// Approve all pending scripts
+def pendingScripts = scriptApproval.getPendingScripts()
+pendingScripts.each { script ->
+    println "Approving script: ${script.script.substring(0, Math.min(100, script.script.length()))}..."
+    scriptApproval.approveScript(script.getHash())
+}
+
+// Approve all pending signatures
+def pendingSignatures = scriptApproval.getPendingSignatures()
+pendingSignatures.each { signature ->
+    println "Approving signature: ${signature.signature}"
+    scriptApproval.approveSignature(signature.signature)
+}
+
+// Approve all pending classpath entries
+def pendingClasspaths = scriptApproval.getPendingClasspathEntries()
+pendingClasspaths.each { classpath ->
+    println "Approving classpath: ${classpath.getHash()}"
+    scriptApproval.approveClasspathEntry(classpath.getHash())
+}
+
+println "\nApproval complete!"
+println "Approved ${pendingScripts.size()} scripts"
+println "Approved ${pendingSignatures.size()} signatures"
+println "Approved ${pendingClasspaths.size()} classpath entries"

--- a/auto-approve.sh
+++ b/auto-approve.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Auto-approve pending Jenkins scripts
+# This script connects to your local Jenkins and approves all pending scripts/signatures
+
+JENKINS_URL="http://localhost:8080"
+JENKINS_USER="dbjwhs"
+JENKINS_PASS="jenkins"
+
+echo "Auto-approving pending Jenkins scripts..."
+
+# Method 1: Using docker exec to run the groovy script directly in Jenkins container
+docker exec jenkins bash -c "cat > /tmp/approve.groovy << 'EOF'
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval
+
+def scriptApproval = ScriptApproval.get()
+
+// Approve all pending scripts
+scriptApproval.getPendingScripts().each { script ->
+    scriptApproval.approveScript(script.getHash())
+}
+
+// Approve all pending signatures  
+scriptApproval.getPendingSignatures().each { signature ->
+    scriptApproval.approveSignature(signature.signature)
+}
+
+println 'All pending scripts and signatures approved!'
+EOF
+"
+
+# Execute the script in Jenkins script console
+docker exec jenkins bash -c "echo 'jenkins.model.Jenkins.instance.doEval(new File(\"/tmp/approve.groovy\").text)' | java -jar /opt/jenkins-cli.jar -s http://localhost:8080 -auth ${JENKINS_USER}:${JENKINS_PASS} groovy ="
+
+echo "Script approval complete!"

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -19,6 +19,12 @@ jenkins:
     enabled: true
 
 security:
+  # Option 1: Disable sandbox for Job DSL scripts (recommended for development)
+  # This allows Job DSL scripts to run without script approval
+  jobDsl:
+    scriptSecurity:
+      sandbox: false
+      
   scriptApproval:
     approvedSignatures:
       # Basic Groovy/Java methods
@@ -63,6 +69,19 @@ security:
       - "staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.lang.Object groovy.lang.Closure"
       - "staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Object groovy.lang.Closure"
       - "staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll java.lang.Object groovy.lang.Closure"
+      
+      # Job DSL specific signatures (prevents most DSL approval issues)
+      - "new groovy.util.ConfigSlurper"
+      - "staticMethod jenkins.model.Jenkins getInstance"
+      - "method jenkins.model.Jenkins getItem java.lang.String"
+      - "method hudson.model.ItemGroup getItem java.lang.String"
+      - "staticMethod hudson.model.Hudson getInstance"
+      - "method hudson.model.Item getName"
+      - "method hudson.model.Item getFullName"
+      - "new java.util.HashMap"
+      - "new java.util.ArrayList"
+      - "staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.Map java.util.Map$Entry"
+      - "method groovy.util.ConfigObject getProperty java.lang.String"
 
 credentials:
   system:


### PR DESCRIPTION
## Summary
- Eliminates manual script approval requirements for Job DSL changes
- Adds automated approval scripts for development workflow
- Pre-configures common DSL signatures to prevent approval prompts

## Changes
1. **Disabled Job DSL Sandbox** (`jenkins.yaml`)
   - Job DSL scripts now run without sandbox restrictions in development
   - Prevents the need for script approvals when making DSL changes

2. **Pre-approved Signatures** (`jenkins.yaml`)
   - Added comprehensive list of Job DSL specific method signatures
   - Covers common operations like Jenkins instance access, collection operations

3. **Auto-approval Script** (`auto-approve.sh`)
   - One-command solution to approve all pending scripts
   - Can be run whenever approval prompts appear

4. **Script Console Helper** (`approve-scripts.groovy`)
   - Groovy script for Jenkins Script Console
   - Programmatically approves all pending items

## Test Plan
- [ ] Restart Jenkins with updated configuration
- [ ] Make a DSL change to trigger script approval
- [ ] Verify DSL changes work without manual approval
- [ ] Test auto-approve.sh script if approval still needed

🤖 Generated with [Claude Code](https://claude.ai/code)