### PR TITLE
Fix junit parameter syntax in CQL pipeline

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -431,7 +431,7 @@ pipelineJob('cpp-projects/cql-build') {
                                     
                                     // Archive test results and logs
                                     archiveArtifacts artifacts: 'build/test_results.xml', allowEmptyArchive: true
-                                    archiveArtifacts artifacts: 'build/Testing/**/*', allowEmptyArchive: true
+                                    archiveArtifacts artifacts: 'build/Testing/**', allowEmptyArchive: true
                                 }
                             }
                         }

--- a/jobs.groovy
+++ b/jobs.groovy
@@ -414,8 +414,8 @@ pipelineJob('cpp-projects/cql-build') {
                             post {
                                 always {
                                     // Publish test results if available
-                                    junit testResultsPattern: '**/test_results.xml', allowEmptyResults: true
-                                    junit testResultsPattern: '**/Testing/**/*.xml', allowEmptyResults: true
+                                    junit testResults: '**/test_results.xml', allowEmptyResults: true
+                                    junit testResults: '**/Testing/**/*.xml', allowEmptyResults: true
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- Fix invalid `testResultsPattern` parameter to correct `testResults` in junit steps
- Resolves Jenkins pipeline compilation error preventing CQL builds
- Enables proper GoogleTest XML result publishing in Jenkins dashboard

## Changes
- Updated junit step parameter from `testResultsPattern` to `testResults`
- Applied fix to both test result patterns in CQL pipeline post section

## Test Plan
- [x] Pipeline compiles without syntax errors
- [ ] CQL build job runs successfully 
- [ ] Test results appear in Jenkins dashboard

🤖 Generated with [Claude Code](https://claude.ai/code)