### PR TITLE
Fix Jenkins startup failure due to Groovy syntax error

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -412,10 +412,8 @@ pipelineJob('cpp-projects/cql-build') {
                                         // Also test the main executable
                                         if (fileExists('cql')) {
                                             echo "Testing main CQL executable..."
-                                            sh '''
-                                                ./cql --help || echo "CQL help command completed"
-                                                ./cql --version || echo "CQL version command completed"
-                                            '''
+                                            sh "./cql --help || echo 'CQL help command completed'"
+                                            sh "./cql --version || echo 'CQL version command completed'"
                                         } else {
                                             echo "Main cql executable not found"
                                         }


### PR DESCRIPTION
## Summary
- Fixed Jenkins initialization failure caused by Groovy parsing error in Job DSL
- Replaced problematic multi-line shell script syntax with separate sh blocks
- Resolves "unexpected token: cql" error at line 417 in jobs.groovy

## Problem
Jenkins was failing to start with this error:
```
script: 417: unexpected token: cql @ line 417, column 51.
                               ./cql --vers
                                 ^
```

## Solution
Changed from:
```groovy
sh '''
    ./cql --help || echo "CQL help command completed"
    ./cql --version || echo "CQL version command completed"
'''
```

To:
```groovy
sh "./cql --help || echo 'CQL help command completed'"
sh "./cql --version || echo 'CQL version command completed'"
```

## Test plan
- [x] Jenkins starts successfully without syntax errors
- [x] CQL pipeline job loads properly
- [x] No regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)