### PR TITLE
fix: Use params.BRANCH instead of env.BRANCH_NAME for CQL API key check

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -391,7 +391,7 @@ pipelineJob('cpp-projects/cql-build') {
                                             echo "Found cql_test executable, running tests..."
                                             
                                             // Use Anthropic API key for live tests on main branch only
-                                            if (env.BRANCH_NAME == 'main') {
+                                            if (params.BRANCH == 'main') {
                                                 echo "Running with live API integration on main branch"
                                                 withCredentials([string(credentialsId: 'anthropic-api-key', variable: 'ANTHROPIC_API_KEY')]) {
                                                     sh './cql_test --gtest_output=xml:test_results.xml'


### PR DESCRIPTION
## Problem
The CQL build pipeline was not loading Anthropic API key credentials for live integration tests, even on main branch builds. Debug output showed:

```
DEBUG: ANTHROPIC_API_KEY env var - present: 0, length: 0
DEBUG: CQL_API_KEY env var - present: 0, length: 0
```

## Root Cause
The pipeline was checking `env.BRANCH_NAME == 'main'` to decide whether to load API key credentials, but in parameterized builds, `env.BRANCH_NAME` is undefined. Only `params.BRANCH` contains the branch name.

## Solution
Changed the condition from:
```groovy
if (env.BRANCH_NAME == 'main') {
```

To:
```groovy
if (params.BRANCH == 'main') {
```

## Impact
- Live integration tests will now properly load API key credentials on main branch builds
- All 7 Anthropic API integration tests should pass instead of being skipped
- No impact on non-main branch builds (still skip API tests as intended)

## Testing
After this fix is merged and deployed to Jenkins, the next CQL build should show:
```
DEBUG: ANTHROPIC_API_KEY env var - present: 1, length: 95
```

And all 7 live integration tests should pass.

🤖 Generated with [Claude Code](https://claude.ai/code)